### PR TITLE
Kan 73 add key mapping option

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -6,7 +6,10 @@
   <component name="ChangeListManager">
     <list default="true" id="c2d1df9e-7633-4932-824c-2c1f0ea58909" name="변경" comment="">
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/engine/Core.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/engine/Core.java" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/engine/DrawManager.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/engine/DrawManager.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/engine/Frame.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/engine/Frame.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/engine/InputManager.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/engine/InputManager.java" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/screen/GameScreen.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/screen/GameScreen.java" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/screen/OptionScreen.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/screen/OptionScreen.java" afterDir="false" />
     </list>
@@ -49,24 +52,25 @@
     <option name="hideEmptyMiddlePackages" value="true" />
     <option name="showLibraryContents" value="true" />
   </component>
-  <component name="PropertiesComponent">{
-  &quot;keyToString&quot;: {
-    &quot;Application.Core.executor&quot;: &quot;Run&quot;,
-    &quot;RunOnceActivity.ShowReadmeOnStart&quot;: &quot;true&quot;,
-    &quot;kotlin-language-version-configured&quot;: &quot;true&quot;,
-    &quot;last_opened_file_path&quot;: &quot;C:/Users/limul/Desktop/College/2_grade/2_semester/소프트웨어 개발 실무/workspace2/Invaders-SDP/src/entity&quot;,
-    &quot;node.js.detected.package.eslint&quot;: &quot;true&quot;,
-    &quot;node.js.detected.package.tslint&quot;: &quot;true&quot;,
-    &quot;node.js.selected.package.eslint&quot;: &quot;(autodetect)&quot;,
-    &quot;node.js.selected.package.tslint&quot;: &quot;(autodetect)&quot;,
-    &quot;nodejs_package_manager_path&quot;: &quot;npm&quot;,
-    &quot;project.structure.last.edited&quot;: &quot;모듈&quot;,
-    &quot;project.structure.proportion&quot;: &quot;0.15&quot;,
-    &quot;project.structure.side.proportion&quot;: &quot;0.28390804&quot;,
-    &quot;vue.rearranger.settings.migration&quot;: &quot;true&quot;,
-    &quot;애플리케이션.Core.executor&quot;: &quot;Run&quot;
+  <component name="PropertiesComponent"><![CDATA[{
+  "keyToString": {
+    "Application.Core.executor": "Run",
+    "RunOnceActivity.ShowReadmeOnStart": "true",
+    "git-widget-placeholder": "KAN-73-add-key-mapping-option",
+    "kotlin-language-version-configured": "true",
+    "last_opened_file_path": "C:/Users/limul/Desktop/College/2_grade/2_semester/소프트웨어 개발 실무/workspace2/Invaders-SDP/src/entity",
+    "node.js.detected.package.eslint": "true",
+    "node.js.detected.package.tslint": "true",
+    "node.js.selected.package.eslint": "(autodetect)",
+    "node.js.selected.package.tslint": "(autodetect)",
+    "nodejs_package_manager_path": "npm",
+    "project.structure.last.edited": "모듈",
+    "project.structure.proportion": "0.15",
+    "project.structure.side.proportion": "0.28390804",
+    "vue.rearranger.settings.migration": "true",
+    "애플리케이션.Core.executor": "Run"
   }
-}</component>
+}]]></component>
   <component name="RecentsManager">
     <key name="CreateClassDialog.RecentsKey">
       <recent name="clove" />
@@ -107,14 +111,6 @@
         <item itemvalue="애플리케이션.Core" />
       </list>
     </recent_temporary>
-  </component>
-  <component name="SharedIndexes">
-    <attachedChunks>
-      <set>
-        <option value="bundled-jdk-9823dce3aa75-b114ca120d71-intellij.indexing.shared.core-IU-242.21829.142" />
-        <option value="bundled-js-predefined-d6986cc7102b-7c0b70fcd90d-JavaScript-IU-242.21829.142" />
-      </set>
-    </attachedChunks>
   </component>
   <component name="SpellCheckerSettings" RuntimeDictionaries="0" Folders="0" CustomDictionaries="0" DefaultDictionary="애플리케이션 수준" UseSingleDictionary="true" transferred="true" />
   <component name="TaskManager">
@@ -162,19 +158,9 @@
     </option>
   </component>
   <component name="Vcs.Log.Tabs.Properties">
-    <option name="OPEN_GENERIC_TABS">
-      <map>
-        <entry key="d8a76686-41bf-4f81-bdf0-ee761e77b1ae" value="TOOL_WINDOW" />
-      </map>
-    </option>
     <option name="TAB_STATES">
       <map>
         <entry key="MAIN">
-          <value>
-            <State />
-          </value>
-        </entry>
-        <entry key="d8a76686-41bf-4f81-bdf0-ee761e77b1ae">
           <value>
             <State>
               <option name="FILTERS">
@@ -182,20 +168,12 @@
                   <entry key="branch">
                     <value>
                       <list>
-                        <option value="HEAD" />
-                      </list>
-                    </value>
-                  </entry>
-                  <entry key="structure">
-                    <value>
-                      <list>
-                        <option value="dir:C:/dev/hanyang/2-2/SoftwareDevelop/Invaders-SDP/src/inventory_develop" />
+                        <option value="origin/KAN-67-preprocessing" />
                       </list>
                     </value>
                   </entry>
                 </map>
               </option>
-              <option name="SHOW_ONLY_AFFECTED_CHANGES" value="true" />
             </State>
           </value>
         </entry>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -5,13 +5,11 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="c2d1df9e-7633-4932-824c-2c1f0ea58909" name="변경" comment="">
+      <change afterPath="$PROJECT_DIR$/src/Test/screen/KeyMappingOptionTesting.java" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/engine/Core.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/engine/Core.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/Invaders-SDP.iml" beforeDir="false" afterPath="$PROJECT_DIR$/Invaders-SDP.iml" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/src/engine/DrawManager.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/engine/DrawManager.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/engine/Frame.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/engine/Frame.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/engine/InputManager.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/engine/InputManager.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/screen/GameScreen.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/screen/GameScreen.java" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/src/screen/OptionScreen.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/screen/OptionScreen.java" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/src/screen/KeyMappingOption.java" beforeDir="false" afterPath="$PROJECT_DIR$/src/screen/KeyMappingOption.java" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -22,6 +20,7 @@
     <option name="RECENT_TEMPLATES">
       <list>
         <option value="Class" />
+        <option value="JUnit5 Test Class" />
       </list>
     </option>
   </component>
@@ -55,16 +54,30 @@
   <component name="PropertiesComponent"><![CDATA[{
   "keyToString": {
     "Application.Core.executor": "Run",
+    "Downloaded.Files.Path.Enabled": "false",
+    "JUnit.KeyMappingOptionTest.executor": "Run",
+    "JUnit.KeyMappingOptionTest.testHandleVerticalMenuNavigation_MoveUp.executor": "Run",
+    "JUnit.KeyMappingOptionTest.testKeyMappingUpdate.executor": "Run",
+    "JUnit.KeyMappingOptionTest.testNextOptionCyclesToFirst.executor": "Run",
+    "JUnit.KeyMappingOptionTest.testNextOption_CyclesToFirst.executor": "Run",
+    "JUnit.KeyMappingOptionTesting$nextOption.executor": "Run",
+    "JUnit.KeyMappingOptionTesting$previousOption.executor": "Run",
+    "JUnit.KeyMappingOptionTesting.nextOption.executor": "Run",
+    "Repository.Attach.Annotations": "false",
+    "Repository.Attach.JavaDocs": "false",
+    "Repository.Attach.Sources": "false",
     "RunOnceActivity.ShowReadmeOnStart": "true",
+    "com.intellij.testIntegration.createTest.CreateTestDialog.defaultLibrary": "JUnit5",
+    "com.intellij.testIntegration.createTest.CreateTestDialog.defaultLibrarySuperClass.JUnit5": "",
     "git-widget-placeholder": "KAN-73-add-key-mapping-option",
     "kotlin-language-version-configured": "true",
-    "last_opened_file_path": "C:/Users/limul/Desktop/College/2_grade/2_semester/소프트웨어 개발 실무/workspace2/Invaders-SDP/src/entity",
+    "last_opened_file_path": "C:/Users/limul/Desktop/College/2_grade/2_semester/소프트웨어 개발 실무/workspace/Invaders-SDP",
     "node.js.detected.package.eslint": "true",
     "node.js.detected.package.tslint": "true",
     "node.js.selected.package.eslint": "(autodetect)",
     "node.js.selected.package.tslint": "(autodetect)",
     "nodejs_package_manager_path": "npm",
-    "project.structure.last.edited": "모듈",
+    "project.structure.last.edited": "라이브러리",
     "project.structure.proportion": "0.15",
     "project.structure.side.proportion": "0.28390804",
     "vue.rearranger.settings.migration": "true",
@@ -83,6 +96,12 @@
     <key name="MoveFile.RECENT_KEYS">
       <recent name="C:\Users\limul\Desktop\College\2_grade\2_semester\소프트웨어 개발 실무\workspace2\Invaders-SDP\src" />
     </key>
+    <key name="CreateTestDialog.Recents.Supers">
+      <recent name="" />
+    </key>
+    <key name="CreateTestDialog.RecentsKey">
+      <recent name="screen" />
+    </key>
     <key name="CopyClassDialog.RECENTS_KEY">
       <recent name="entity" />
       <recent name="engine" />
@@ -90,10 +109,8 @@
       <recent name="clove" />
     </key>
   </component>
-  <component name="RunManager">
+  <component name="RunManager" selected="애플리케이션.Core">
     <configuration name="Core" type="Application" factoryName="Application" temporary="true" nameIsGenerated="true">
-      <option name="ALTERNATIVE_JRE_PATH" value="22" />
-      <option name="ALTERNATIVE_JRE_PATH_ENABLED" value="true" />
       <option name="MAIN_CLASS_NAME" value="engine.Core" />
       <module name="Invaders-SDP" />
       <extension name="coverage">
@@ -106,9 +123,75 @@
         <option name="Make" enabled="true" />
       </method>
     </configuration>
+    <configuration name="KeyMappingOptionTest.testNextOption_CyclesToFirst" type="JUnit" factoryName="JUnit" temporary="true" nameIsGenerated="true">
+      <module name="Invaders-SDP" />
+      <extension name="coverage">
+        <pattern>
+          <option name="PATTERN" value="screen.*" />
+          <option name="ENABLED" value="true" />
+        </pattern>
+      </extension>
+      <option name="PACKAGE_NAME" value="screen" />
+      <option name="MAIN_CLASS_NAME" value="screen.KeyMappingOptionTest" />
+      <option name="METHOD_NAME" value="testNextOption_CyclesToFirst" />
+      <option name="TEST_OBJECT" value="method" />
+      <method v="2">
+        <option name="Make" enabled="true" />
+      </method>
+    </configuration>
+    <configuration name="KeyMappingOptionTesting$nextOption" type="JUnit" factoryName="JUnit" temporary="true" nameIsGenerated="true">
+      <module name="Invaders-SDP" />
+      <extension name="coverage">
+        <pattern>
+          <option name="PATTERN" value="screen.*" />
+          <option name="ENABLED" value="true" />
+        </pattern>
+      </extension>
+      <option name="PACKAGE_NAME" value="screen.KeyMappingOptionTesting" />
+      <option name="MAIN_CLASS_NAME" value="screen.KeyMappingOptionTesting$nextOption" />
+      <option name="TEST_OBJECT" value="class" />
+      <method v="2">
+        <option name="Make" enabled="true" />
+      </method>
+    </configuration>
+    <configuration name="KeyMappingOptionTesting$previousOption" type="JUnit" factoryName="JUnit" temporary="true" nameIsGenerated="true">
+      <module name="Invaders-SDP" />
+      <extension name="coverage">
+        <pattern>
+          <option name="PATTERN" value="screen.*" />
+          <option name="ENABLED" value="true" />
+        </pattern>
+      </extension>
+      <option name="PACKAGE_NAME" value="screen.KeyMappingOptionTesting" />
+      <option name="MAIN_CLASS_NAME" value="screen.KeyMappingOptionTesting$previousOption" />
+      <option name="TEST_OBJECT" value="class" />
+      <method v="2">
+        <option name="Make" enabled="true" />
+      </method>
+    </configuration>
+    <configuration name="KeyMappingOptionTesting.nextOption" type="JUnit" factoryName="JUnit" temporary="true" nameIsGenerated="true">
+      <module name="Invaders-SDP" />
+      <extension name="coverage">
+        <pattern>
+          <option name="PATTERN" value="screen.*" />
+          <option name="ENABLED" value="true" />
+        </pattern>
+      </extension>
+      <option name="PACKAGE_NAME" value="screen" />
+      <option name="MAIN_CLASS_NAME" value="screen.KeyMappingOptionTesting" />
+      <option name="METHOD_NAME" value="nextOption" />
+      <option name="TEST_OBJECT" value="method" />
+      <method v="2">
+        <option name="Make" enabled="true" />
+      </method>
+    </configuration>
     <recent_temporary>
       <list>
         <item itemvalue="애플리케이션.Core" />
+        <item itemvalue="JUnit.KeyMappingOptionTesting$previousOption" />
+        <item itemvalue="JUnit.KeyMappingOptionTesting$nextOption" />
+        <item itemvalue="JUnit.KeyMappingOptionTesting.nextOption" />
+        <item itemvalue="JUnit.KeyMappingOptionTest.testNextOption_CyclesToFirst" />
       </list>
     </recent_temporary>
   </component>
@@ -179,5 +262,10 @@
         </entry>
       </map>
     </option>
+  </component>
+  <component name="com.intellij.coverage.CoverageDataManagerImpl">
+    <SUITE FILE_PATH="coverage/Invaders_SDP$Core.ic" NAME="Core 커버리지 결과" MODIFIED="1732155376167" SOURCE_PROVIDER="com.intellij.coverage.DefaultCoverageFileProvider" RUNNER="idea" COVERAGE_BY_TEST_ENABLED="false" COVERAGE_TRACING_ENABLED="true">
+      <FILTER>engine.*</FILTER>
+    </SUITE>
   </component>
 </project>

--- a/Invaders-SDP.iml
+++ b/Invaders-SDP.iml
@@ -5,8 +5,11 @@
     <content url="file://$MODULE_DIR$">
       <sourceFolder url="file://$MODULE_DIR$/res" type="java-resource" />
       <sourceFolder url="file://$MODULE_DIR$/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/src/Test" isTestSource="true" />
     </content>
     <orderEntry type="jdk" jdkName="22" jdkType="JavaSDK" />
     <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="library" name="icegreen.greenmail.junit5" level="project" />
+    <orderEntry type="library" name="bluecatcode.mockito.1.10.19.extended" level="project" />
   </component>
 </module>

--- a/src/Test/screen/KeyMappingOptionTesting.java
+++ b/src/Test/screen/KeyMappingOptionTesting.java
@@ -1,0 +1,76 @@
+package screen;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+
+class KeyMappingOptionTesting {
+
+    private KeyMappingOption keyMappingOption;
+
+    @BeforeEach
+    void setUp() {
+        keyMappingOption = new KeyMappingOption(630, 720, 60);
+        keyMappingOption.actions = Arrays.asList("MOVE_UP", "MOVE_DOWN", "SHOOT"); // 옵션 리스트 초기화
+        keyMappingOption.selectedIndex = 0; // 초기 선택 인덱스
+    }
+
+    @Nested
+    class nextOption{
+        @Test
+        public void testNextOption_CyclesToFirst() {
+            // GIVEN: 선택된 인덱스가 마지막 항목
+            keyMappingOption.selectedIndex = keyMappingOption.actions.size() - 1;
+
+            // WHEN: nextOption 호출
+            keyMappingOption.nextOption();
+
+            // THEN: 인덱스가 첫 번째로 순환
+            assertEquals(0, keyMappingOption.selectedIndex, "Index should cycle to the first option");
+        }
+
+        @Test
+        public void testNextOption_IncrementIndex() {
+            // GIVEN: 선택된 인덱스가 마지막이 아님
+            keyMappingOption.selectedIndex = 1;
+
+            // WHEN: nextOption 호출
+            keyMappingOption.nextOption();
+
+            // THEN: 인덱스가 1 증가
+            assertEquals(2, keyMappingOption.selectedIndex, "Index should increment by 1");
+        }
+    }
+
+    @Nested
+    class previousOption {
+        @Test
+        public void testPreviousOption_CyclesToLast() {
+            // GIVEN: 선택된 인덱스가 첫 번째 항목
+            keyMappingOption.selectedIndex = 0;
+
+            // WHEN: previousOption 호출
+            keyMappingOption.previousOption();
+
+            // THEN: 인덱스가 마지막 항목으로 순환
+            assertEquals(keyMappingOption.actions.size() - 1, keyMappingOption.selectedIndex,
+                    "Index should cycle to the last option");
+        }
+
+        @Test
+        public void testPreviousOption_DecrementsIndex() {
+            // GIVEN: 선택된 인덱스가 첫 번째가 아님
+            keyMappingOption.selectedIndex = 2;
+
+            // WHEN: previousOption 호출
+            keyMappingOption.previousOption();
+
+            // THEN: 인덱스가 1 감소
+            assertEquals(1, keyMappingOption.selectedIndex, "Index should decrement by 1");
+        }
+    }
+}

--- a/src/engine/Core.java
+++ b/src/engine/Core.java
@@ -3,11 +3,16 @@ package engine;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Stack;
+import java.util.Map;
+import java.util.HashMap;
 import java.util.logging.ConsoleHandler;
 import java.util.logging.FileHandler;
 import java.util.logging.Handler;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
+import java.awt.event.KeyEvent;
 
 import Currency.CurrencyManager;
 import Currency.RoundState;
@@ -91,6 +96,21 @@ public final class Core {
 
 	public static void setSavedVolumeSelectionCode(int newCode) {
 		savedVolumeSelectionCode = newCode;
+	}
+
+	private static Stack<Screen> screenStack = new Stack<>();
+
+	private static Map<String, Integer> keyMappings = new HashMap<>();
+
+	static {
+		// 기본 키 매핑 설정
+		keyMappings.put("MOVE_UP", KeyEvent.VK_W);
+		keyMappings.put("MOVE_DOWN", KeyEvent.VK_S);
+		keyMappings.put("MOVE_LEFT", KeyEvent.VK_A);
+		keyMappings.put("MOVE_RIGHT", KeyEvent.VK_D);
+		keyMappings.put("SHOOT", KeyEvent.VK_SPACE);
+		keyMappings.put("PAUSE", KeyEvent.VK_P);
+		keyMappings.put("GO_BACK", KeyEvent.VK_ESCAPE);
 	}
 	/**
 	 * Test implementation.
@@ -181,9 +201,16 @@ public final class Core {
 							&& gameState.getLivesRemaining() < MAX_LIVES;
 
 					GameState prevState = gameState;
+
+//					pushScreen(new GameScreen(gameState,
+//							gameSettings.get(gameState.getLevel() - 1),
+//							bonusLife, width, height, FPS));
+//					currentScreen = peekScreen();
+
 					currentScreen = new GameScreen(gameState,
 							gameSettings.get(gameState.getLevel() - 1),
 							bonusLife, width, height, FPS);
+
 					LOGGER.info("Starting " + WIDTH + "x" + HEIGHT
 							+ " game screen at " + FPS + " fps.");
 					frame.setScreen(currentScreen);
@@ -382,12 +409,6 @@ public final class Core {
 		System.exit(0);
 	}
 
-	/**
-	 * Constructor, not called.
-	 */
-	private Core() {
-
-	}
 
 	/**
 	 * Controls access to the logger.
@@ -469,7 +490,39 @@ public final class Core {
 	public static UpgradeManager getUpgradeManager() {
 		return UpgradeManager.getInstance();
 	}
+
 	public static Frame getFrame() {
 		return frame;
+	}
+
+	public static void pushScreen(Screen screen) {
+		if (getFrame().getCurrentScreen() != null) {
+			// 현재 화면을 스택에 저장
+			screenStack.push(getFrame().getCurrentScreen());
+		}
+		// 새 화면 설정
+		getFrame().setScreen(screen);
+	}
+
+	public static void popScreen(){
+		if (getFrame().getCurrentScreen() != null) {
+			// 현재 화면을 스택에 저장
+			screenStack.pop();
+		}
+	}
+
+	// 키 매핑 정보 가져오기
+	public static int getKeyCode(String action) {
+		return keyMappings.getOrDefault(action, -1); // -1: 매핑되지 않은 키
+	}
+
+	// 키 매핑 업데이트
+	public static void updateKeyMapping(String action, int keyCode) {
+		keyMappings.put(action, keyCode);
+	}
+
+	// 모든 키 매핑 정보 가져오기
+	public static Map<String, Integer> getKeyMappings() {
+		return new HashMap<>(keyMappings);
 	}
 }

--- a/src/engine/DrawManager.java
+++ b/src/engine/DrawManager.java
@@ -10,6 +10,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.*;
 import java.util.logging.Logger;
+import java.awt.event.KeyEvent;
+
 
 import Currency.RoundState;
 import Currency.Gem;
@@ -1111,7 +1113,8 @@ public class DrawManager {
 
 		// 'PRESS P TO RESUME', 'PRESS Q TO TERMINATE' 안내문구 그리기
 		backBufferGraphics.setColor(Color.GRAY);
-		drawCenteredRegularString(screen, "PRESS P TO RESUME", screen.getHeight() / 5);
+			String resumeText = new String("PRESS "+KeyEvent.getKeyText(Core.getKeyCode("PAUSE"))+" TO RESUME");
+		drawCenteredRegularString(screen, resumeText, screen.getHeight() / 5);
 		drawCenteredRegularString(screen, "PRESS Q TO TERMINATE", screen.getHeight() / 4);// 화면 중간에 안내문구 표시
 	}
 

--- a/src/engine/DrawManager.java
+++ b/src/engine/DrawManager.java
@@ -1122,16 +1122,18 @@ public class DrawManager {
 		String[] volumes = {"VOLUME0", "VOLUME1", "VOLUME2", "VOLUME3", "VOLUME4", "VOLUME5"};
 		String volume = volumes[volumeIndex];
 
+		String keyMapping = "Modify KeyMapping ";
+
 		if (option == 1)
 			backBufferGraphics.setColor(Color.CYAN);
 		else
 			backBufferGraphics.setColor(Color.WHITE);
 
 		String bgmDisplay = "< " + selectedBGM + " >";
-		drawCenteredRegularString(screen, bgmString + ": " + bgmDisplay, screen.getHeight() / 4 * 2);
+		drawCenteredRegularString(screen, bgmString + ": " + bgmDisplay, screen.getHeight() / 8 * 3);
 
 		backBufferGraphics.setColor(Color.PINK);
-		drawCenteredRegularString(screen, "VOLUME", screen.getHeight() / 4 * 2 + fontRegularMetrics.getHeight() * 6);
+		drawCenteredRegularString(screen, "VOLUME", screen.getHeight() / 8 * 4 - fontRegularMetrics.getHeight() * 1);
 
 		if (option == 2) {
 			switch (volumeIndex) {
@@ -1160,7 +1162,55 @@ public class DrawManager {
 		} else {
 			backBufferGraphics.setColor(Color.WHITE); // 기본 색상
 		}
-		drawCenteredRegularString(screen, volume, screen.getHeight() / 4 * 2 + fontRegularMetrics.getHeight() * 8);
+		drawCenteredRegularString(screen, volume, screen.getHeight() / 8 * 4 + fontRegularMetrics.getHeight() * 1);
 
+		if (option == 3)
+			backBufferGraphics.setColor(Color.CYAN);
+		else
+			backBufferGraphics.setColor(Color.WHITE);
+
+		drawCenteredRegularString(screen, keyMapping, screen.getHeight() / 8 * 5);
 	}
+
+	/**
+	 * 일반 문자열을 화면에 그리는 메서드.
+	 *
+	 * @param screen 화면 객체.
+	 * @param text 표시할 텍스트.
+	 * @param x 텍스트의 X 좌표.
+	 * @param y 텍스트의 Y 좌표.
+	 */
+	public void drawString(final Screen screen, final String text, final int x, final int y) {
+		backBufferGraphics.setFont(fontRegular);
+		backBufferGraphics.setColor(Color.WHITE);
+		backBufferGraphics.drawString(text, x, y);
+	}
+
+	/**
+	 * 강조된 문자열을 화면에 그리는 메서드.
+	 *
+	 * @param screen 화면 객체.
+	 * @param text 강조 표시할 텍스트.
+	 * @param x 텍스트의 X 좌표.
+	 * @param y 텍스트의 Y 좌표.
+	 */
+	public void drawHighlightedString(Screen screen, String text, int x, int y) {
+		backBufferGraphics.setFont(fontBig); // 강조를 위해 큰 폰트 사용
+		backBufferGraphics.setColor(Color.YELLOW); // 강조 색상
+		int width = backBufferGraphics.getFontMetrics().stringWidth(text);
+		int height = backBufferGraphics.getFontMetrics().getHeight();
+
+		// 강조 배경 그리기
+		backBufferGraphics.fillRect(x - 5, y - height + 5, width + 10, height);
+
+		// 텍스트 그리기
+		backBufferGraphics.setColor(Color.BLACK);
+		backBufferGraphics.drawString(text, x, y);
+	}
+	public void drawKeyMapping(final Screen screen, final int option) {
+		backBufferGraphics.setColor(Color.WHITE);
+		drawCenteredRegularString(screen, "testing", screen.getHeight() / 8 * 5);
+	}
+
+
 }

--- a/src/engine/Frame.java
+++ b/src/engine/Frame.java
@@ -77,4 +77,7 @@ public class Frame extends JFrame {
 	public final int getHeight() {
 		return this.height;
 	}
+
+	public Screen getCurrentScreen() {return this.currentScreen;}
+
 }

--- a/src/engine/InputManager.java
+++ b/src/engine/InputManager.java
@@ -81,4 +81,9 @@ public final class InputManager implements KeyListener {
 	public void keyTyped(final KeyEvent key) {
 
 	}
+
+	public void keyReleased(int vkEscape) {
+		if (vkEscape >= 0 && vkEscape < NUM_KEYS)
+			keys[vkEscape] = false;
+	}
 }

--- a/src/screen/GameScreen.java
+++ b/src/screen/GameScreen.java
@@ -298,7 +298,7 @@ public class GameScreen extends Screen {
 		long currentTime = System.currentTimeMillis();
 
 		// P, Q 키 입력 처리
-		if ((inputManager.isKeyDown(KeyEvent.VK_P) || inputManager.isKeyDown(KeyEvent.VK_Q))
+		if ((inputManager.isKeyDown(Core.getKeyCode("PAUSE")) || inputManager.isKeyDown(KeyEvent.VK_Q))
 				&& currentTime - lastPauseToggleTime > PAUSE_TOGGLE_DELAY) {
 			this.isPaused = !this.isPaused;
 			lastPauseToggleTime = currentTime;
@@ -306,7 +306,8 @@ public class GameScreen extends Screen {
 
 			if (this.isPaused) {
 				Core.getLogger().info("Pausing the game.");
-				Core.getFrame().setScreen(new OptionScreen(this.width, this.height, this.fps));
+//				Core.pushScreen(new OptionScreen(this.width, this.height, this.fps, this));
+				Core.getFrame().setScreen(new OptionScreen(this.width, this.height, this.fps, this));
 				pauseStartTime = currentTime; // 일시 정지 시작 시간 기록
 				return;
 			} else {
@@ -395,8 +396,8 @@ public class GameScreen extends Screen {
 
 	private void handleShipMovement() {
 		if (!this.ship.isDestroyed()) {
-			boolean moveRight = inputManager.isKeyDown(KeyEvent.VK_RIGHT) || inputManager.isKeyDown(KeyEvent.VK_D);
-			boolean moveLeft = inputManager.isKeyDown(KeyEvent.VK_LEFT) || inputManager.isKeyDown(KeyEvent.VK_A);
+			boolean moveRight = inputManager.isKeyDown(Core.getKeyCode("MOVE_RIGHT"));
+			boolean moveLeft = inputManager.isKeyDown(Core.getKeyCode("MOVE_LEFT"));
 			boolean isRightBorder = this.ship.getPositionX() + this.ship.getWidth() + this.ship.getSpeed() > this.width - 1;
 			boolean isLeftBorder = this.ship.getPositionX() - this.ship.getSpeed() < 1;
 
@@ -408,7 +409,7 @@ public class GameScreen extends Screen {
 				this.ship.moveLeft();
 				this.backgroundMoveLeft = true;
 			}
-			if (inputManager.isKeyDown(KeyEvent.VK_ENTER)) {
+			if (inputManager.isKeyDown(Core.getKeyCode("SHOOT"))) {
 				if (this.ship.shoot(this.bullets)) {
 					this.bulletsShot++;
 					this.fire_id++;

--- a/src/screen/KeyMappingOption.java
+++ b/src/screen/KeyMappingOption.java
@@ -1,0 +1,135 @@
+package screen;
+
+import engine.Cooldown;
+import engine.Core;
+
+import java.awt.*;
+import java.awt.event.KeyEvent;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public class KeyMappingOption extends Screen {
+    private List<String> actions; // 액션 목록
+    private Map<String, Integer> keyMappings; // 현재 키 매핑 정보
+    private int selectedIndex; // 선택된 액션의 인덱스
+    private boolean waitingForKeyInput; // 키 입력 대기 상태
+    private Cooldown selectionCooldown; // 입력 쿨다운
+    private static final int SELECTION_TIME = 120; // 쿨다운 시간(ms)
+
+    public KeyMappingOption(int width, int height, int fps) {
+        super(width, height, fps);
+
+        this.actions = new ArrayList<>(Core.getKeyMappings().keySet()); // Core에서 액션 목록 가져오기
+        this.keyMappings = Core.getKeyMappings(); // Core에서 현재 키 매핑 정보 가져오기
+        this.selectedIndex = 0;
+        this.waitingForKeyInput = false;
+        this.selectionCooldown = Core.getCooldown(SELECTION_TIME);
+        this.selectionCooldown.reset();
+    }
+
+    @Override
+    public final int run() {
+        super.run();
+        return this.returnCode;
+    }
+
+    @Override
+    public void update() {
+        super.update();
+        draw();
+
+        if (waitingForKeyInput) {
+            handleKeyInput(); // 키 입력 대기 상태 처리
+        } else {
+            if ((inputManager.isKeyDown(Core.getKeyCode("GO_BACK")) || inputManager.isKeyDown(KeyEvent.VK_BACK_SPACE)) && this.selectionCooldown.checkFinished()) {
+                Core.getLogger().info("Go back to OptionScreen.");
+                inputManager.keyReleased(KeyEvent.VK_ESCAPE);
+                this.isRunning = false; // 옵션 화면으로 돌아감a
+            }
+
+            if (this.selectionCooldown.checkFinished()) {
+                handleVerticalMenuNavigation(); // 메뉴 탐색 처리
+                handleKeyMappingSelection(); // 키 매핑 선택 처리
+                this.selectionCooldown.reset();
+            }
+        }
+    }
+
+    private void handleVerticalMenuNavigation() {
+        if (inputManager.isKeyDown(Core.getKeyCode("MOVE_UP"))) {
+            previousOption(); // 이전 항목으로 이동
+        }
+        if (inputManager.isKeyDown(Core.getKeyCode("MOVE_DOWN"))) {
+            nextOption(); // 다음 항목으로 이동
+        }
+    }
+
+    private void handleKeyMappingSelection() {
+        if (inputManager.isKeyDown(KeyEvent.VK_CAPS_LOCK) && this.selectionCooldown.checkFinished()) {
+            waitingForKeyInput = true; // 키 입력 대기 상태로 전환
+            this.selectionCooldown.reset();
+        }
+    }
+
+    private void handleKeyInput() {
+        for (int keyCode = 0; keyCode < 256; keyCode++) {
+            if (inputManager.isKeyDown(keyCode) && this.selectionCooldown.checkFinished()) {
+                String selectedAction = actions.get(selectedIndex);
+                Core.updateKeyMapping(selectedAction, keyCode); // Core에 키 매핑 업데이트
+                this.keyMappings = Core.getKeyMappings(); // 업데이트된 매핑 정보 가져오기
+                waitingForKeyInput = false; // 입력 대기 상태 해제
+                this.selectionCooldown.reset();
+                break;
+            }
+        }
+    }
+
+    private void nextOption() {
+        if (selectedIndex >= actions.size() - 1) {
+            selectedIndex = 0; // 마지막 항목에서 첫 번째로 순환
+        } else {
+            selectedIndex++;
+        }
+    }
+
+    private void previousOption() {
+        if (selectedIndex <= 0) {
+            selectedIndex = actions.size() - 1; // 첫 번째 항목에서 마지막으로 순환
+        } else {
+            selectedIndex--;
+        }
+    }
+
+    public void draw() {
+        drawManager.initDrawing(this);
+
+        // 제목
+        drawManager.backBufferGraphics.setColor(Color.GREEN);
+        drawManager.drawCenteredBigString(this, "KEY MAPPING", this.height / 8);
+
+        drawManager.backBufferGraphics.setColor(Color.GRAY);
+        drawManager.drawCenteredRegularString(this, "Press CapsLock to Modify", this.height / 8*2 - drawManager.fontRegularMetrics.getHeight()*2);
+
+        // 각 키 매핑 항목 표시
+        for (int i = 0; i < actions.size(); i++) {
+            String action = actions.get(i);
+            String keyName = KeyEvent.getKeyText(keyMappings.get(action));
+
+            // 선택된 항목 강조
+            if (i == selectedIndex) {
+                drawManager.drawHighlightedString(this, action + ": " + keyName, this.width / 4, this.height / 4 + i * 40 + drawManager.fontRegularMetrics.getHeight());
+            } else {
+                drawManager.drawString(this, action + ": " + keyName, this.width / 4, this.height / 4 + i * 40 + drawManager.fontRegularMetrics.getHeight());
+            }
+        }
+
+        // 키 입력 대기 상태에서 안내 메시지 표시
+        if (waitingForKeyInput) {
+            drawManager.backBufferGraphics.setColor(Color.white);
+            drawManager.drawCenteredRegularString(this, "Press a key to map", this.height / 4 + actions.size()*40 + drawManager.fontRegularMetrics.getHeight()*2);
+        }
+
+        drawManager.completeDrawing(this);
+    }
+}

--- a/src/screen/KeyMappingOption.java
+++ b/src/screen/KeyMappingOption.java
@@ -10,9 +10,9 @@ import java.util.List;
 import java.util.Map;
 
 public class KeyMappingOption extends Screen {
-    private List<String> actions; // 액션 목록
+    List<String> actions; // 액션 목록
     private Map<String, Integer> keyMappings; // 현재 키 매핑 정보
-    private int selectedIndex; // 선택된 액션의 인덱스
+    int selectedIndex; // 선택된 액션의 인덱스
     private boolean waitingForKeyInput; // 키 입력 대기 상태
     private Cooldown selectionCooldown; // 입력 쿨다운
     private static final int SELECTION_TIME = 120; // 쿨다운 시간(ms)
@@ -56,7 +56,7 @@ public class KeyMappingOption extends Screen {
         }
     }
 
-    private void handleVerticalMenuNavigation() {
+    void handleVerticalMenuNavigation() {
         if (inputManager.isKeyDown(Core.getKeyCode("MOVE_UP"))) {
             previousOption(); // 이전 항목으로 이동
         }
@@ -72,7 +72,7 @@ public class KeyMappingOption extends Screen {
         }
     }
 
-    private void handleKeyInput() {
+    void handleKeyInput() {
         for (int keyCode = 0; keyCode < 256; keyCode++) {
             if (inputManager.isKeyDown(keyCode) && this.selectionCooldown.checkFinished()) {
                 String selectedAction = actions.get(selectedIndex);
@@ -85,7 +85,7 @@ public class KeyMappingOption extends Screen {
         }
     }
 
-    private void nextOption() {
+    void nextOption() {
         if (selectedIndex >= actions.size() - 1) {
             selectedIndex = 0; // 마지막 항목에서 첫 번째로 순환
         } else {
@@ -93,7 +93,7 @@ public class KeyMappingOption extends Screen {
         }
     }
 
-    private void previousOption() {
+    void previousOption() {
         if (selectedIndex <= 0) {
             selectedIndex = actions.size() - 1; // 첫 번째 항목에서 마지막으로 순환
         } else {

--- a/src/screen/OptionScreen.java
+++ b/src/screen/OptionScreen.java
@@ -3,6 +3,7 @@ package screen;
 import engine.Core;
 
 import java.awt.event.KeyEvent;
+
 import engine.Cooldown;
 import engine.SoundManager;
 import engine.Frame;
@@ -20,15 +21,15 @@ public class OptionScreen extends Screen {
     private final int maxBGMState = 2;
     private int volumeSelectionCode;
     private Cooldown selectionCooldown;
-    private static final int SELECTION_TIME = 200;
+    private static final int SELECTION_TIME = 120;
     private static SoundManager sm;
+    private GameScreen gameScreen;
 
-    public OptionScreen(int width, int height, int fps) {
+    public OptionScreen(int width, int height, int fps, GameScreen gamesc) {
         super(width, height, fps);
         this.volumeSelectionCode = Core.getSavedVolumeSelectionCode();
         this.returnCode = 1; // Default return code for resuming the game
-        this.selectionCooldown = Core.getCooldown(SELECTION_TIME);
-        this.selectionCooldown.reset();
+        this.gameScreen = gamesc;
         sm = SoundManager.getInstance();
 
         bgmOptions = new ArrayList<>();
@@ -51,27 +52,31 @@ public class OptionScreen extends Screen {
         super.update();
         draw();
 
-        if ((inputManager.isKeyDown(KeyEvent.VK_P) || inputManager.isKeyDown(KeyEvent.VK_Q))
+        if ((inputManager.isKeyDown(Core.getKeyCode("GO_BACK")) || inputManager.isKeyDown(Core.getKeyCode("PAUSE")) || inputManager.isKeyDown(KeyEvent.VK_Q))
                 && this.inputDelay.checkFinished()) {
+            Core.getLogger().info("Resuming GameScreen.");
+//            Core.popScreen();
             Core.setSavedVolumeSelectionCode(this.volumeSelectionCode); // GameScreen으로 돌아가기 위한 코드
-            this.isRunning = false; // Exit the pause screen and return to the game
+            this.isRunning = false;
         }
 
-        if(this.selectionCooldown.checkFinished() && this.inputDelay.checkFinished()){
+        if (this.selectionCooldown.checkFinished() && this.inputDelay.checkFinished()) {
             handleVerticalMenuNavigation();
-            handleVolumeCode();
             handleBGMCode();
+            handleVolumeCode();
+            openKeyMapping();
             this.selectionCooldown.reset();
         }
-
     }
 
     private void handleVerticalMenuNavigation() {
-        if (inputManager.isKeyDown(KeyEvent.VK_UP) || inputManager.isKeyDown(KeyEvent.VK_W)) {
+        if (inputManager.isKeyDown(Core.getKeyCode("MOVE_UP"))) {
+            Core.getLogger().info("Pressed uping to " + returnCode);
             previousOptionItem();
             this.selectionCooldown.reset();
         }
-        if (inputManager.isKeyDown(KeyEvent.VK_DOWN) || inputManager.isKeyDown(KeyEvent.VK_S)) {
+        if (inputManager.isKeyDown(Core.getKeyCode("MOVE_DOWN"))) {
+            Core.getLogger().info("Pressed Downing to " + returnCode);
             nextOptionItem();
             this.selectionCooldown.reset();
         }
@@ -79,12 +84,12 @@ public class OptionScreen extends Screen {
 
     private void handleBGMCode() {
         if (this.returnCode == 1) {
-            if (inputManager.isKeyDown(KeyEvent.VK_LEFT) || inputManager.isKeyDown(KeyEvent.VK_A)) {
+            if (inputManager.isKeyDown(Core.getKeyCode("MOVE_LEFT"))) {
                 previousBGMState();
                 this.selectionCooldown.reset();
                 playSelectedBGM();
             }
-            if (inputManager.isKeyDown(KeyEvent.VK_RIGHT) || inputManager.isKeyDown(KeyEvent.VK_D)) {
+            if (inputManager.isKeyDown(Core.getKeyCode("MOVE_RIGHT"))) {
                 nextBGMState();
                 this.selectionCooldown.reset();
                 playSelectedBGM();
@@ -114,8 +119,19 @@ public class OptionScreen extends Screen {
         }
     }
 
+
+    private void openKeyMapping() {
+        if (this.returnCode == 3) {
+            if (inputManager.isKeyDown(KeyEvent.VK_ENTER) || inputManager.isKeyDown(KeyEvent.VK_SPACE)) {
+                Core.getLogger().info("Open Key Mapping");
+                Core.pushScreen(new KeyMappingOption(this.width, this.height, this.fps));
+                Core.getLogger().info("Close Key Mapping");
+//                Core.getFrame().setScreen(new KeyMappingOption(this.width, this.height, this.fps));
+            }
+        }
+    }
     private void nextOptionItem() {
-        if (this.returnCode >= 2)
+        if (this.returnCode >= 3)
             this.returnCode = 1;
         else
             this.returnCode++;
@@ -123,7 +139,7 @@ public class OptionScreen extends Screen {
 
     private void previousOptionItem() {
         if (this.returnCode <= 1)
-            this.returnCode = 2;
+            this.returnCode = 3;
         else
             this.returnCode--;
     }
@@ -152,7 +168,7 @@ public class OptionScreen extends Screen {
     private void draw() {
         drawManager.initDrawing(this);
         drawManager.drawOption(this);
-        drawManager.drawSoundOption(this, this.returnCode,this.volumeSelectionCode, this.bgmState, this.bgmOptions);
+        drawManager.drawSoundOption(this, this.returnCode, this.volumeSelectionCode, this.bgmState, this.bgmOptions);
         drawManager.completeDrawing(this);
     }
 }


### PR DESCRIPTION
### 개요
![image](https://github.com/user-attachments/assets/32b23f46-2c78-48d9-a187-3af8d90354ab)
- KeyMappingOption 개발
- ingame 내에서의 이동과 발사 조건 동기화
- KeyMappingOptionTesting 테스트 코드 작성



### KeyMappingOption

- draw 매커니즘을 여태까지 Drawmanager에서 처리하다 보니 렉이 걸리는거 같아 이번 개발에서는 동일 클래스에서 개발해봄
- capslock을 통해 입력 모드 전환이 가능함
- 동일 키 입력시 오류 발생 가능
- update() 메소드에서 뒤로가는지 확인
  - 아니라면 입력 대기
    - 위 아래 화살표를 통해 메뉴 이동
    - capslock을 통해 입력 모드 전환, 키 변경
  - 맞다면 현재창 종료, 뒤(OptionScreen)으로 감



### ingame 내에서의 이동과 발사 조건 동기화

- 과거 방향키와 wasd 전부 먹혔지만 변경함
- Core에 있는 keyMapping에 기본 키매핑정보 저장되어 있음
- 메인 메뉴 동기화 아직 안됨



### KeyMappingOptionTesting 테스트 코드 작성

- mockito를 활용한 임의 클래스 가상화 데이터 주입을 통해 더 정확하고 다양한 테스트 코드 작성 시도

  => 실패

- 따로 의견이 없고, 개발 상황으로 보아 mockito 활용은 중단

- 기본적인 외부 클래스 의존도가 없는 함수만 test 코드 개발
