### PR TITLE
Create gradle ci process

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -1,0 +1,46 @@
+name: CI for Java with Gradle
+
+on:
+  push:
+    branches:
+      - main
+      - develop
+  pull_request:
+    branches:
+      - main
+      - develop
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    # 1. Repository Checkout
+    - name: Check out repository
+      uses: actions/checkout@v4
+
+    # 2. Set up JDK
+    - name: Set up JDK 17
+      uses: actions/setup-java@v4
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+        cache: gradle # Gradle 의존성 캐싱
+
+    # 3. Cache Gradle Wrapper and Dependencies
+    - name: Cache Gradle
+      uses: actions/cache@v3
+      with:
+        path: ~/.gradle/caches
+        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+        restore-keys: |
+          ${{ runner.os }}-gradle-
+
+    # 4. Build the Project
+    - name: Build with Gradle
+      run: ./gradlew build --no-daemon
+
+    # 5. Run Tests
+    - name: Run Tests
+      run: ./gradlew test --no-daemon


### PR DESCRIPTION
### Gradle 다운
- Window 환경
  - Gradle.zip 파일 다운
  - path 설정&재부팅
- Mac&Others
  - 명령어를 통한 설치
  - path 설정&재부팅

### Gradlew build.gradle.kts 수정
- 현재 디렉토리 구조 수정하지 않고 인식하도록 수정
- dafualt는 루트 디렉토리 하위의 `app`이 home 디렉토리임
- `../`를 통해 상위 디렉토리로 이동, 폴더 경로 정의
  - lib
  - src
  - main
  - res
- Junit5 사용 정의

### Gradlew build
- `gradlew build`를 통해 build 파일 생성
- `gradlew run`을 통해 프로그램 실행
- `gradlew test`를 통해 프로그램 테스트 코드 실행
  - `./app/build/reports/tests/test/index.html`에 결과 파일 저장됨



### .github/workflows/gradle.yml 생성
- github action에 gradle 설정 추가